### PR TITLE
Updates Pylint and Black formatter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Also look for `TODO` in other locations in the entire template:
 References, to other extension created by our team using the template:
 
 -   Protocol reference: https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/
--   Implementation showing how to handle Linting on file `open`, `save`, and `close`. [Pylint](https://github.com/microsoft/vscode-pylint/blob/main/bundled/linter)
--   Implementation showing how to handle Formatting. [Black Formatter](https://github.com/microsoft/vscode-black-formatter/blob/main/bundled/formatter)
+-   Implementation showing how to handle Linting on file `open`, `save`, and `close`. [Pylint](https://github.com/microsoft/vscode-pylint/tree/main/bundled/tool)
+-   Implementation showing how to handle Formatting. [Black Formatter](https://github.com/microsoft/vscode-black-formatter/tree/main/bundled/tool)
 -   Implementation showing how to handle Code Actions. [isort](https://github.com/microsoft/vscode-isort/blob/main/bundled/formatter)
 
 ## Building and Run the extension


### PR DESCRIPTION
Current links 404s. 
I believe these are the links that show how to implement linting/formatting.