### PR TITLE
Fix atexit exception

### DIFF
--- a/bundled/tool/jsonrpc.py
+++ b/bundled/tool/jsonrpc.py
@@ -131,8 +131,8 @@ class ProcessManager:
         self._rpc: Dict[str, JsonRpc] = {}
         self._lock = threading.Lock()
         self._thread_pool = ThreadPoolExecutor(10)
+        atexit.register(self.stop_all_processes)
 
-    @atexit.register
     def stop_all_processes(self):
         """Send exit command to all processes and shutdown transport."""
         for i in self._rpc.values():


### PR DESCRIPTION
The current implementation results in the "Output" tab for the extension showing:

```
Exception ignored in atexit callback: <function ProcessManager.stop_all_processes at 0x10298a320>
TypeError: ProcessManager.stop_all_processes() missing 1 required positional argument: 'self'
```

(This fixes #83)