### PR TITLE
Fix dependencies of `@vscode/python-extension`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
             "devDependencies": {
                 "@types/fs-extra": "^11.0.1",
                 "@types/glob": "^8.1.0",
-                "@types/node": "14.x",
-                "@types/vscode": "1.75.0",
+                "@types/node": "16.x",
+                "@types/vscode": "1.78.0",
                 "@typescript-eslint/eslint-plugin": "^6.2.0",
                 "@typescript-eslint/parser": "^6.2.0",
                 "@vscode/test-electron": "^2.3.3",
@@ -31,7 +31,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.75.0"
+                "vscode": "^1.78.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -388,9 +388,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.18.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-            "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
+            "version": "16.18.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
+            "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
             "dev": true
         },
         "node_modules/@types/semver": {
@@ -400,9 +400,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+            "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4915,9 +4915,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.18.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-            "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
+            "version": "16.18.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
+            "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
             "dev": true
         },
         "@types/semver": {
@@ -4927,9 +4927,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+            "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "<pytool-module>"
     ],
     "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.78.0"
     },
     "categories": [
         "Programming Languages",
@@ -140,9 +140,9 @@
     },
     "devDependencies": {
         "@types/fs-extra": "^11.0.1",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.78.0",
         "@types/glob": "^8.1.0",
-        "@types/node": "14.x",
+        "@types/node": "16.x",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
         "@vscode/test-electron": "^2.3.3",


### PR DESCRIPTION
`@vscode/python-extension` requires `node>=16.17.1` and `vscode^1.78.0`