### PR TITLE
Separate the libs required by the server from the libs required by the tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .vs/
 .nox/
 bundled/libs/
+bundled/tool-libs/
 **/__pycache__
 **/.pytest_cache
 **/.vs

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -17,18 +17,21 @@ from typing import Any, Optional, Sequence
 # **********************************************************
 # Update sys.path before importing any bundled libraries.
 # **********************************************************
-def update_sys_path(path_to_add: str, strategy: str) -> None:
+def update_sys_path(libs_path: str, tool_libs_path: str, strategy: str) -> None:
     """Add given path to `sys.path`."""
-    if path_to_add not in sys.path and os.path.isdir(path_to_add):
+    if tool_libs_path not in sys.path and os.path.isdir(tool_libs_path):
         if strategy == "useBundled":
-            sys.path.insert(0, path_to_add)
+            sys.path.insert(0, tool_libs_path)
         elif strategy == "fromEnvironment":
-            sys.path.append(path_to_add)
+            sys.path.append(tool_libs_path)
+    if libs_path not in sys.path:
+        sys.path.insert(0, libs_path)
 
 
 # Ensure that we can import LSP libraries, and other bundled libraries.
 update_sys_path(
     os.fspath(pathlib.Path(__file__).parent.parent / "libs"),
+    os.fspath(pathlib.Path(__file__).parent.parent / "tool-libs"),
     os.getenv("LS_IMPORT_STRATEGY", "useBundled"),
 )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,21 @@ def _install_bundle(session: nox.Session) -> None:
         "-r",
         "./requirements.txt",
     )
+    _install_tool_libs(session)
+
+
+def _install_tool_libs(session: nox.Session) -> None:
+    session.install(
+        "-t",
+        "./bundled/tool-libs",
+        "--no-cache-dir",
+        "--implementation",
+        "py",
+        "--no-deps",
+        "--upgrade",
+        "-r",
+        "./requirements-tool.txt",
+    )
 
 
 def _check_files(names: List[str]) -> None:
@@ -36,6 +51,7 @@ def _check_files(names: List[str]) -> None:
 
 def _update_pip_packages(session: nox.Session) -> None:
     session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements.in")
+    session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements-tool.in")
     session.run(
         "pip-compile",
         "--generate-hashes",

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,6 +108,7 @@ def _update_npm_packages(session: nox.Session) -> None:
 def _setup_template_environment(session: nox.Session) -> None:
     session.install("wheel", "pip-tools")
     session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements.in")
+    session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements-tool.in")
     session.run(
         "pip-compile",
         "--generate-hashes",

--- a/requirements-tool.in
+++ b/requirements-tool.in
@@ -1,13 +1,11 @@
-# This file is used to generate requirements.txt.
+# This file is used to generate requirements-tool.txt.
 # NOTE:
 # Use Python 3.7 or greater which ever is the minimum version of the python
 # you plan on supporting when creating the environment or using pip-tools.
-# Only run the commands below to manully upgrade packages in requirements.txt:
+# Only run the commands below to manully upgrade packages in requirements-tool.txt:
 # 1) python -m pip install pip-tools
-# 2) pip-compile --generate-hashes --resolver=backtracking --upgrade ./requirements.in
+# 2) pip-compile --generate-hashes --resolver=backtracking --upgrade ./requirements-tool.in
 # If you are using nox commands to setup or build package you don't need to
 # run the above commands manually.
 
-# Required packages
-pygls
-packaging
+# TODO: Add your tool here


### PR DESCRIPTION
Here's a situation that if someone installed the libs required by server, like `pygls` that incompatible with server, and also installed the tool dependencies, like `yapf` for me. Then I can't use `yapf` I installed in local to format my code. Cause if `import.Strategy` is `useBundled`, I can't use the `yapf` package I installed and if `import.Strategy` is `fromEnvironment`, the server can't launch since the `pygls` is incompatible. Separating the libs required by the server from the libs required by the tool will address it.