### PR TITLE
align default importStrategy to code

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
                     "type": "array"
                 },
                 "<pytool-module>.importStrategy": {
-                    "default": "fromEnvironment",
+                    "default": "useBundled",
                     "description": "Defines where `<pytool-module>` is imported from. This setting may be ignored if `<pytool-module>.path` is set.",
                     "enum": [
                         "useBundled",


### PR DESCRIPTION
Maybe the importStrategy should setup to `useBundled` by default cause the code following
```
update_sys_path(
    os.fspath(pathlib.Path(__file__).parent.parent / "libs"),
    os.getenv("LS_IMPORT_STRATEGY", "useBundled"),
)
```
and
```
def _get_global_defaults():
    return {
        "path": GLOBAL_SETTINGS.get("path", []),
        "interpreter": GLOBAL_SETTINGS.get("interpreter", [sys.executable]),
        "args": GLOBAL_SETTINGS.get("args", []),
        "importStrategy": GLOBAL_SETTINGS.get("importStrategy", "useBundled"),
        "showNotifications": GLOBAL_SETTINGS.get("showNotifications", "off"),
    }
```
And the parameter in other extension, like `vscode-pylint` and `vscode-black-formatter` etc., developed by microsoft (ms-python) is also the `useBundled` by default