### PR TITLE
fix: KeyError of 'cwd' when running pytest formatting

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -313,6 +313,7 @@ def _update_workspace_settings(settings):
     for setting in settings:
         key = uris.to_fs_path(setting["workspace"])
         WORKSPACE_SETTINGS[key] = {
+            "cwd": key,
             **setting,
             "workspaceFS": key,
         }


### PR DESCRIPTION
```
        WORKSPACE_SETTINGS[key] = {
            "cwd": key,
            **setting,
            "workspaceFS": key,
        }
```
if `cwd` already in `settings`, the `"cwd": key` will be override. So this's a safe approach. 